### PR TITLE
Make World Dtor virtual

### DIFF
--- a/include/RavEngine/World.hpp
+++ b/include/RavEngine/World.hpp
@@ -924,7 +924,7 @@ namespace RavEngine {
             return newID;
         }
         
-        ~World();
+        virtual ~World();
         
 		constexpr static uint8_t id_size = 8;
 		Ref<Skybox> skybox;


### PR DESCRIPTION
Make the dtor for world virtual so that derived worlds can clean up manually alloocated resources in their own dtor.